### PR TITLE
Fix Theme.of(context) returns light theme instead of dark

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Spotify UI',
       debugShowCheckedModeBanner: false,
       theme: ThemeData.dark(),
+      themeMode: ThemeMode.dark,
       darkTheme: ThemeData(
         brightness: Brightness.dark,
         appBarTheme: const AppBarTheme(backgroundColor: Colors.black),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Spotify UI',
       debugShowCheckedModeBanner: false,
+      theme: ThemeData.dark(),
       darkTheme: ThemeData(
         brightness: Brightness.dark,
         appBarTheme: const AppBarTheme(backgroundColor: Colors.black),


### PR DESCRIPTION
Hello there, thanks for the awesome tutorial!
After enabling flutter desktop windows, `Theme.of(context)` returns light theme because MaterialApp has `themeMode: ThemeMode.system` by default, and my system has light preferences.
so i solve this by forcing MaterialApp to use dark theme by adding `themeMode: ThemeMode.dark` and  `theme: ThemeData.dark()` (optional)
now it works fine.